### PR TITLE
fix: check and convert keypair to buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const noisePeer = require('noise-peer')
 const EventEmitter = require('events')
 const pump = require('pump')
 const getStream = require('get-stream')
+const isBuffer = require('is-buffer')
 
 const METADATA_NAME = 'p2plex-topics'
 
@@ -17,11 +18,22 @@ class P2Plex extends EventEmitter {
   } = {}) {
     super()
     this.opts = opts
-    this.keyPair = keyPair || noisePeer.keygen()
     this.swarm = hyperswarm({
       multiplex: true,
       ...opts
     })
+
+    let { publicKey, secretKey } = opts.keyPair || noisePeer.keygen()
+    if (!isBuffer(publicKey)) {
+      publicKey = Buffer.from(publicKey)
+    }
+    if (!isBuffer(secretKey)) {
+      secretKey = Buffer.from(secretKey)
+    }
+    this.keyPair = {
+      publicKey,
+      secretKey,
+    }
 
     this.peers = new Set()
 

--- a/package.json
+++ b/package.json
@@ -26,11 +26,12 @@
   "dependencies": {
     "get-stream": "^5.1.0",
     "hyperswarm": "^2.11.2",
+    "is-buffer": "^2.0.4",
     "multiplex": "^6.7.0",
-    "noise-peer": "^1.1.0",
+    "noise-peer": "^2.1.0",
     "pump": "^3.0.0"
   },
   "devDependencies": {
-    "supertape": "^1.2.4"
+    "supertape": "^2.0.1"
   }
 }


### PR DESCRIPTION
These are the changes I made to get p2plex working in a next.js application ([with these aliases via webpack](https://www.npmjs.com/package/dat-sdk#compile-with-webpack-webpackconfigjs)). I have not tested to confirm that these changes work in a node.js env yet, but wanted to get this PR open! Related: https://github.com/RangerMauve/p2plex/issues/2
I also bumped some dependencies